### PR TITLE
Dependencie and Compatibility Update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: set up JDK 1.8
+      - name: set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Build with Gradle
         id: build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "net.justdave.mcstatus"
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 9
-        versionName '1.0.7'
+        versionCode 10
+        versionName '1.0.8'
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "net.justdave.mcstatus"
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 8
-        versionName '1.0.6'
+        versionCode 9
+        versionName '1.0.7'
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion 31
+    buildToolsVersion '31.0.0'
     def applicationName = "MCStatus"
     defaultConfig {
         applicationId "net.justdave.mcstatus"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 8
         versionName '1.0.6'
     }
@@ -21,9 +21,10 @@ android {
     productFlavors {
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
+    ndkVersion '24.0.7956693 rc2'
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
             def newApkName

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:fullBackupContent="@xml/backup_descriptor">
         <activity
             android:name="net.justdave.mcstatus.MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/res/raw-de/about_info.txt
+++ b/app/src/main/res/raw-de/about_info.txt
@@ -1,9 +1,9 @@
 Sie haben einen Fehler gefunden oder haben eine Idee für die App:<br>
 <b>https://github.com/justdave/MCStatus/issues</b><br>
 <br>
-Copyright 2014-2021 David D. Miller<br>
+Copyright 2014-2022 David D. Miller<br>
 Copyright 2020 Rick van Schijndel<br>
-Copyright 2020-2021 Yan-Luca Lentzen<br>
+Copyright 2020-2022 Yan-Luca Lentzen<br>
 <br>
 Lizensiert unter der MIT Lizenz<br>
 <br>

--- a/app/src/main/res/raw/about_info.txt
+++ b/app/src/main/res/raw/about_info.txt
@@ -1,9 +1,9 @@
 To request new features or file bug reports, please visit<br>
-<b>https://github.com/justdave/MCStatus</b><br>
+<b>https://github.com/justdave/MCStatus/issues</b><br>
 <br>
-Copyright 2014-2021 David D. Miller<br>
+Copyright 2014-2022 David D. Miller<br>
 Copyright 2020 Rick van Schijndel<br>
-Copyright 2020-2021 Yan-Luca Lentzen<br>
+Copyright 2020-2022 Yan-Luca Lentzen<br>
 <br>
 Licensed under the MIT License<br>
 <br>

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:7.0.4'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
@@ -15,7 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 31 22:58:01 CEST 2020
+#Wed Dec 15 09:38:53 CET 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/playstore/de/changelog.txt
+++ b/playstore/de/changelog.txt
@@ -1,9 +1,14 @@
+<version name="1.0.8">
+* Sprache aktualisiert: Deutsch, English
+* Abhängigkeiten aktualisiert
+* Ziel API 31 (Android 12)
+</version>
 <version name="1.0.7">
 * Sprache aktualisiert: Deutsch
-* Material Design für Android 5.0 (Lollipop) und neuer.
+* Neues App Design für Android 5.0 und neuer.
 </version>
 <version name="1.0.6">
-* Ziel API 30 (Android R)
+* Ziel API 30 (Android 11)
 * Code aufgeräumt - App sollte jetzt weniger Abstürzen
 * Sprache hinzugefügt: Deutsch (Danke @chaosfreak93 !)
 </version>

--- a/playstore/en/changelog.txt
+++ b/playstore/en/changelog.txt
@@ -1,8 +1,14 @@
+<version name="1.0.8">
+* Update German and English localization
+* Update Dependencies
+* Target API 31 (Android 12)
+</version>
 <version name="1.0.7">
 * Update German localization
+* New App Design for Android 5.0 and above.
 </version>
 <version name="1.0.6">
-* Target API 30 (Android R)
+* Target API 30 (Android 11)
 * Lots of back-end code cleanup - should reduce crashes.
 * Add German localization (thanks, @chaosfreak93 !)
 </version>


### PR DESCRIPTION
- Bump Gradle to 7.0.4
- Bump Gradle Wrapper to 7.0.2
- Bump Target Android API to 31
- Bump Java Version to 11
- Bump Build Tools to 31.0.0
- Replace JCenter with MavenCentral
- Bump App Version to 1.0.8
- Update Changelog
- Update Copyright